### PR TITLE
fix: sync jax/jaxlib pins to match optax 0.2.8 PyPI requirements

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,63 +23,84 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
-            UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
     steps:
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Configure binfmt_misc
+      if: matrix.os == 'ubuntu'
+      shell: bash
+      run: |
+        if [[ "$(uname -m)" == "x86_64" ]]; then
+          docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
+        fi
 
     - name: Build on Linux
       id: build-linux
       if: matrix.os == 'ubuntu'
       env:
-        CONFIG: ${{ matrix.CONFIG }}
-        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
-        DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
         CI: github_actions
-        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.CONDA_FORGE_DOCKER_RUN_ARGS }}"
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONDA_FORGE_DOCKER_RUN_ARGS: ${{ matrix.docker_run_args }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
+        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
       shell: bash
       run: |
-        if [[ "$(uname -m)" == "x86_64" ]]; then
-          echo "::group::Configure binfmt_misc"
-          docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
-        fi
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
         if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
           export IS_PR_BUILD="True"
         else
           export IS_PR_BUILD="False"
         fi
-        echo "::endgroup::"
         ./.scripts/run_docker_build.sh
 
     - name: Build on macOS
       id: build-macos
       if: matrix.os == 'macos'
       env:
-        CONFIG: ${{ matrix.CONFIG }}
-        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
         CI: github_actions
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
       shell: bash
       run: |
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
         if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
           export IS_PR_BUILD="True"
         else
@@ -97,14 +118,14 @@ jobs:
         set "sha=%GITHUB_SHA%"
         call ".scripts\run_win_build.bat"
       env:
-        # default value; make it explicit, as it needs to match with artefact
-        # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
-        MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
-        PYTHONUNBUFFERED: 1
-        CONFIG: ${{ matrix.CONFIG }}
         CI: github_actions
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        PYTHONUNBUFFERED: 1
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!.recipe_maintainers.json
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -36,7 +36,7 @@ mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-
 echo > /opt/conda/conda-meta/history
 micromamba install --root-prefix ~/.conda --prefix /opt/conda \
     --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=26.3"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -58,18 +58,33 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    # differences between conda-build vs. rattler-build
+    #   - 1 step (conda debug + manually open shell) vs. 2 step (rb debug {setup, shell})
+    #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
+    #   - --output-id vs. --output-name
+    #   - --clobber-file vs. none
+    #   - none vs. --target-platform
+    conda debug \
+        "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
+        ${BUILD_OUTPUT_ID:+--output-id "${BUILD_OUTPUT_ID}"} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
     # Drop into an interactive shell
     /bin/bash
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
+    # differences between conda-build vs. rattler-build
+    #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
+    #   - --suppress-variables vs. none
+    #   - --clobber-file vs. none
+    #   - none vs. --target-platform
+    #   - --extra-meta a=b c=d vs. --extra-meta a=b --extra-meta c=d
+    conda-build \
+        "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        --suppress-variables \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -11,6 +11,8 @@ source .scripts/logging_utils.sh
 
 set -xeo pipefail
 
+DOCKER_EXECUTABLE="${DOCKER_EXECUTABLE:-docker}"
+
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
 PROVIDER_DIR="$(basename "$THISDIR")"
 
@@ -27,7 +29,7 @@ if [[ "${sha:-}" == "" ]]; then
   popd
 fi
 
-docker info
+${DOCKER_EXECUTABLE} info
 
 # In order for the conda-build process in the container to write to the mounted
 # volumes, we need to run with the same id as the host machine, which is
@@ -35,6 +37,7 @@ docker info
 export HOST_USER_ID=$(id -u)
 # Check if docker-machine is being used (normally on OSX) and get the uid from
 # the VM
+
 if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
     export HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
 fi
@@ -76,27 +79,56 @@ if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
 
-( endgroup "Configure Docker" ) 2> /dev/null
+# Default volume suffix for Docker (preserve original behavior)
+VOLUME_SUFFIX=",z"
 
+# Podman-specific handling
+if [ "${DOCKER_EXECUTABLE}" = "podman" ]; then
+    # Fix file permissions for rootless podman builds
+    podman unshare chown -R ${HOST_USER_ID}:${HOST_USER_ID} "${ARTIFACTS}"
+    podman unshare chown -R ${HOST_USER_ID}:${HOST_USER_ID} "${RECIPE_ROOT}"
+
+    # Add SELinux label only if enforcing
+    if command -v getenforce &>/dev/null && [ "$(getenforce)" = "Enforcing" ]; then
+        VOLUME_SUFFIX=",z"
+    else
+        VOLUME_SUFFIX=""
+    fi
+fi
+
+# When running on GitHub Actions, mount the step summary file into the container
+# and point GITHUB_STEP_SUMMARY at it so that rattler-build's GitHub integration
+# can write its summary. GitHub writes the file out to the job summary after the
+# step finishes.
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    DOCKER_RUN_ARGS="${DOCKER_RUN_ARGS} -v ${GITHUB_STEP_SUMMARY}:/home/conda/github_step_summary:rw${VOLUME_SUFFIX},delegated -e GITHUB_STEP_SUMMARY=/home/conda/github_step_summary"
+fi
+
+( endgroup "Configure Docker" ) 2> /dev/null
 ( startgroup "Start Docker" ) 2> /dev/null
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 export IS_PR_BUILD="${IS_PR_BUILD:-False}"
-docker pull "${DOCKER_IMAGE}"
-docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
-           -e CONFIG \
-           -e HOST_USER_ID \
-           -e UPLOAD_PACKAGES \
-           -e IS_PR_BUILD \
-           -e GIT_BRANCH \
-           -e UPLOAD_ON_BRANCH \
-           -e CI \
-           -e FEEDSTOCK_NAME \
-           -e CPU_COUNT \
-           -e BUILD_WITH_CONDA_DEBUG \
+
+${DOCKER_EXECUTABLE} pull "${DOCKER_IMAGE}"
+
+${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw${VOLUME_SUFFIX},delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw${VOLUME_SUFFIX},delegated \
            -e BUILD_OUTPUT_ID \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e CI \
+           -e CONFIG \
+           -e CPU_COUNT \
+           -e FEEDSTOCK_NAME \
+           -e GIT_BRANCH \
+           -e GITHUB_ACTIONS \
+           -e HOST_USER_ID \
+           -e IS_PR_BUILD \
+           -e RATTLER_BUILD_COLOR \
+           -e RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION \
+           -e UPLOAD_ON_BRANCH \
+           -e UPLOAD_PACKAGES \
            -e flow_run_id \
            -e remote_url \
            -e sha \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Current build status
 <table><tr>
     <td>All platforms:</td>
     <td>
-      <img src="https://img.shields.io/badge/noarch-disabled-lightgrey.svg" alt="noarch disabled">
+      <a href="https://github.com/conda-forge/optax-feedstock/actions/workflows/conda-build.yml">
+        <img src="https://github.com/conda-forge/optax-feedstock/actions/workflows/conda-build.yml/badge.svg?event=push&branch=main">
+      </a>
     </td>
   </tr>
 </table>

--- a/build-locally.py
+++ b/build-locally.py
@@ -98,7 +98,10 @@ def main(args=None):
     p.add_argument(
         "--debug",
         action="store_true",
-        help="Setup debug environment using `conda debug`",
+        help=(
+            "Setup debug environment using `conda debug` "
+            "(or `rattler-build debug` for rattler-build recipes)"
+        ),
     )
     p.add_argument("--output-id", help="If running debug, specify the output to setup.")
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 5b225b35066fc3eebaa4d798f1b4173b4d57d1a480610908981f8343b50af0b0
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
@@ -24,8 +24,8 @@ requirements:
     - python >={{ python_min }}
     - absl-py >=0.7.1
     - chex >=0.1.86
-    - jax >=0.4.27
-    - jaxlib >=0.4.27
+    - jax >=0.5.3
+    - jaxlib >=0.5.3
     - numpy >=1.18.0
     - typing_extensions >=3.10
     - etils


### PR DESCRIPTION
## Summary

optax 0.2.8 on PyPI requires `jax>=0.5.3` / `jaxlib>=0.5.3` (see [pyproject.toml](https://github.com/google-deepmind/optax/blob/main/pyproject.toml)), but the conda-forge recipe still pins `jax>=0.4.27` / `jaxlib>=0.4.27` — left over from the 0.2.5 era.

This mismatch causes conda solvers to pair the latest optax with a JAX version that is 3 minor releases behind, breaking downstream packages (e.g. reported in google-deepmind/optax#1594).

## Changes

- `jax >=0.4.27` → `jax >=0.5.3`
- `jaxlib >=0.4.27` → `jaxlib >=0.5.3`
- Build number: `0` → `1` (required to re-release the same version tarball with corrected metadata)

## Checklist

- [x] Used a personal fork of the feedstock to propose changes
- [x] No new version bump — only dependency pins corrected for existing 0.2.8

Ref: google-deepmind/optax#1594

Closes #32 