### PR TITLE
Update optax recipe to match optax/pyproject.toml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,8 +24,8 @@ requirements:
     - python >={{ python_min }}
     - absl-py >=0.7.1
     - chex >=0.1.86
-    - jax >=0.4.27
-    - jaxlib >=0.4.27
+    - jax >=0.5.3
+    - jaxlib >=0.5.3
     - numpy >=1.18.0
     - typing_extensions >=3.10
     - etils


### PR DESCRIPTION
Hey, I'm an optax maintainer responding to the issue opened for optax here:  https://github.com/google-deepmind/optax/pull/1688

Could we match the recipe here to the match optax's [pyproject.toml](https://github.com/google-deepmind/optax/blob/main/pyproject.toml) requirements?